### PR TITLE
ignore ST1005 to allow capitalisation on user facing strings

### DIFF
--- a/cmd/git-remote-ipld/main.go
+++ b/cmd/git-remote-ipld/main.go
@@ -19,6 +19,7 @@ const (
 
 func Main(args []string, reader io.Reader, writer io.Writer, logger *log.Logger) error {
 	if len(args) < 3 {
+		//lint:ignore ST1005 user facing message
 		return fmt.Errorf("Usage: git-remote-ipns remote-name url")
 	}
 

--- a/util/compare.go
+++ b/util/compare.go
@@ -52,17 +52,21 @@ func CompareDirs(srcPath, dstPath string, ignore []string) error {
 	for i := 0; float64(i) < math.Max(float64(len(srcEntries)), float64(len(dstEntries))); i++ {
 		if i >= len(srcEntries) {
 			dstSubPath := filepath.Join(dstPath, dstEntries[i].Name())
+			//lint:ignore ST1005 user facing error
 			return fmt.Errorf("File %s in destination directory does not exist in source directory %s", dstSubPath, srcPath)
 		}
 		if i >= len(dstEntries) {
 			srcSubPath := filepath.Join(srcPath, srcEntries[i].Name())
+			//lint:ignore ST1005 user facing error
 			return fmt.Errorf("File %s in source directory does not exist in destination directory %s", srcSubPath, dstPath)
 		}
 		if srcEntries[i].Name() < dstEntries[i].Name() {
 			srcSubPath := filepath.Join(srcPath, srcEntries[i].Name())
+			//lint:ignore ST1005 user facing error
 			return fmt.Errorf("File %s in source directory does not exist in destination directory %s", srcSubPath, dstPath)
 		} else if srcEntries[i].Name() > dstEntries[i].Name() {
 			dstSubPath := filepath.Join(dstPath, dstEntries[i].Name())
+			//lint:ignore ST1005 user facing error
 			return fmt.Errorf("File %s in destination directory does not exist in source directory %s", dstSubPath, srcPath)
 		}
 	}
@@ -159,6 +163,7 @@ func CompareZlib(file1, file2 string) error {
 			if err1 == io.EOF && err2 == io.EOF {
 				return nil
 			} else if err1 == io.EOF || err2 == io.EOF {
+				//lint:ignore ST1005 user facing error
 				return fmt.Errorf("File %s != %s", file1, file2)
 			} else {
 				return err1
@@ -166,6 +171,7 @@ func CompareZlib(file1, file2 string) error {
 		}
 
 		if !bytes.Equal(b1, b2) {
+			//lint:ignore ST1005 user facing error
 			return fmt.Errorf("File %s != %s", file1, file2)
 		}
 	}


### PR DESCRIPTION
`staticcheck ./...` complains about `error strings should not be capitalized (ST1005)` on the lines modified in this PR. AFAICT they are all user facing messages/errors so the capitalisation does make sense there.

Clearing these errors will allow merging integrated CI workflow (https://github.com/ipfs-shipyard/git-remote-ipld/pull/35) eventually.